### PR TITLE
Make completion case-insensitive

### DIFF
--- a/supercharge.plugin.zsh
+++ b/supercharge.plugin.zsh
@@ -1,7 +1,7 @@
 # completions
 autoload -Uz compinit
 zstyle ':completion:*' menu select
-zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}' 'r:|=*' 'l:|=* r:|=*'
+zstyle ':completion:*' matcher-list '' 'm:{a-zA-Z}={A-Za-z}' 'r:|=*' 'l:|=* r:|=*'
 zmodload zsh/complist
 _comp_options+=(globdots)		# Include hidden files.
 zle_highlight=('paste:none')

--- a/supercharge.plugin.zsh
+++ b/supercharge.plugin.zsh
@@ -1,6 +1,7 @@
 # completions
 autoload -Uz compinit
 zstyle ':completion:*' menu select
+zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}' 'r:|=*' 'l:|=* r:|=*'
 zmodload zsh/complist
 _comp_options+=(globdots)		# Include hidden files.
 zle_highlight=('paste:none')


### PR DESCRIPTION
Make the match case insensitive for the whole string, not just the start.