### PR TITLE
refactor: handle completion dump files nicer

### DIFF
--- a/supercharge.plugin.zsh
+++ b/supercharge.plugin.zsh
@@ -7,10 +7,14 @@ zstyle ':completion:*' matcher-list '' 'm:{a-zA-Z}={A-Za-z}' 'r:|=*' 'l:|=* r:|=
 zmodload zsh/complist
 _comp_options+=(globdots)		# Include hidden files.
 zle_highlight=('paste:none')
-for dump in "${ZDOTDIR:-$HOME}/.zcompdump"(N.mh+24); do
+
+_comp_files=(${ZDOTDIR:-$HOME}/.zcompdump(N.mh+24))
+if [[ -n $_comp_files ]]; then
   compinit
-done
-compinit -C
+  touch ${ZDOTDIR:-$HOME}/.zcompdump
+else
+  compinit -C
+fi
 
 unsetopt BEEP
 setopt AUTO_CD

--- a/supercharge.plugin.zsh
+++ b/supercharge.plugin.zsh
@@ -15,6 +15,7 @@ if [[ -n $_comp_files ]]; then
 else
   compinit -C
 fi
+unset _comp_files
 
 unsetopt BEEP
 setopt AUTO_CD


### PR DESCRIPTION
Now the .zcompdump file is kept younger than cache time even if it isn't regenerated.