### PR TITLE
don't modify user's path.

### DIFF
--- a/supercharge.plugin.zsh
+++ b/supercharge.plugin.zsh
@@ -46,7 +46,7 @@ zle -N down-line-or-beginning-search
 autoload -Uz colors && colors
 
 # exports
-export PATH="$HOME/.local/bin:$PATH"
+# export PATH="$HOME/.local/bin:$PATH"
 
 # bindings
 bindkey -s '^x' '^usource ${ZDOTDIR:-$HOME}/.zshrc\n'


### PR DESCRIPTION
Modifying user's path causes a lot of confusion for the user. If the user already have ~/.local/bin in their path (through .zprofile for example), then this directory will be listed twice in the path.